### PR TITLE
Make axum types public

### DIFF
--- a/oasgen/src/lib.rs
+++ b/oasgen/src/lib.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 #![allow(unused)]
-mod server;
+pub mod server;
 mod format;
 
 pub use format::*;

--- a/oasgen/src/server.rs
+++ b/oasgen/src/server.rs
@@ -12,11 +12,11 @@ use oasgen_core::{OaSchema};
 
 #[cfg_attr(docsrs, doc(cfg(feature = "actix")))]
 #[cfg(feature = "actix")]
-mod actix;
+pub mod actix;
 #[cfg_attr(docsrs, doc(cfg(feature = "axum")))]
 #[cfg(feature = "axum")]
-mod axum;
-mod none;
+pub mod axum;
+pub mod none;
 
 static OPERATION_LOOKUP: Lazy<HashMap<&'static str, &'static (dyn Fn() -> Operation + Send + Sync)>> = Lazy::new(|| {
     let mut map = HashMap::new();


### PR DESCRIPTION
Makes router types public so they can be stored in structs.