### PR TITLE
Corrected operation_id

### DIFF
--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -131,7 +131,6 @@ pub fn oasgen(attr: TokenStream, input: TokenStream) -> TokenStream {
         })
         .collect::<Vec<_>>();
     let first_tag = attr.tags.iter().flatten().map(|v| v.value()).take(1).next().unwrap_or_default();
-    // println!("#####:{tags_vec:?}");
 
     let summary = attr
         .summary

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -130,6 +130,9 @@ pub fn oasgen(attr: TokenStream, input: TokenStream) -> TokenStream {
             }
         })
         .collect::<Vec<_>>();
+    let first_tag = attr.tags.iter().flatten().map(|v| v.value()).take(1).next().unwrap_or_default();
+    // println!("#####:{tags_vec:?}");
+
     let summary = attr
         .summary
         .as_ref()
@@ -149,7 +152,7 @@ pub fn oasgen(attr: TokenStream, input: TokenStream) -> TokenStream {
         }
     } else {
         quote! {
-            ::oasgen::__private::fn_path_to_op_id(concat!(module_path!(), "::", #name))
+            ::oasgen::__private::tags_and_fn_path_to_op_id(#first_tag, module_path!(), #name)
         }
     };
     let submit = quote! {

--- a/oasgen/src/lib.rs
+++ b/oasgen/src/lib.rs
@@ -18,7 +18,24 @@ pub mod __private {
     pub use oasgen_core::{SchemaRegister, OperationRegister};
 
     pub fn fn_path_to_op_id(type_name: &str) -> Option<String> {
+        println!("###############:'{type_name}'");
         Some(type_name.split("::").skip(1).collect::<Vec<_>>().join("_"))
+    }
+
+    pub fn tags_and_fn_path_to_op_id(tag: &str, module_path: &str, type_name: &str) -> Option<String> {
+        println!("###############:'{tag}'");
+        println!("###############:'{module_path}'");
+        println!("###############:'{type_name}'");
+        let mut module = module_path.split("::").skip(1).take(1).map(|v| v.to_string()).collect::<Vec<_>>();
+
+        if !tag.is_empty() {
+            module.push(tag.to_string());
+        }
+        module.push(type_name.to_string());
+
+        let res = module.join("_");
+
+        Some(res)
     }
 }
 

--- a/oasgen/src/lib.rs
+++ b/oasgen/src/lib.rs
@@ -18,18 +18,14 @@ pub mod __private {
     pub use oasgen_core::{SchemaRegister, OperationRegister};
 
     pub fn fn_path_to_op_id(type_name: &str) -> Option<String> {
-        println!("###############:'{type_name}'");
         Some(type_name.split("::").skip(1).collect::<Vec<_>>().join("_"))
     }
 
     pub fn tags_and_fn_path_to_op_id(tag: &str, module_path: &str, type_name: &str) -> Option<String> {
-        println!("###############:'{tag}'");
-        println!("###############:'{module_path}'");
-        println!("###############:'{type_name}'");
         let mut module = module_path.split("::").skip(1).take(1).map(|v| v.to_string()).collect::<Vec<_>>();
 
         if !tag.is_empty() {
-            module.push(tag.to_string());
+            module.push(tag.to_string().to_lowercase());
         }
         module.push(type_name.to_string());
 

--- a/oasgen/tests/test-axum/01-hello.yaml
+++ b/oasgen/tests/test-axum/01-hello.yaml
@@ -5,7 +5,7 @@ info:
 paths:
   /hello:
     post:
-      operationId: send_code
+      operationId: auth_send_code
       tags:
         - auth
       description: Endpoint to login by sending a code to the given mobile number

--- a/oasgen/tests/test-axum/04-status_code.yaml
+++ b/oasgen/tests/test-axum/04-status_code.yaml
@@ -8,7 +8,7 @@ paths:
       tags:
       - tasks
       summary: Create a new task with error cases
-      operationId: create_task
+      operationId: tasks_create_task
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
Changed how `operation_id` is populated. Now it uses the root module name, then the first tag, then the function name.